### PR TITLE
add a method to redis split storage exposing any possible errors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+4.0.3 (TBD)
+ - Added new `Update`-like method to redis split storage that return a proper error when something goes wrong
+ - Added new `Update`-like method to redis segment storage that returns a summary of keys added/removed and a more informative error
+
 4.0.2 (Jan 12, 2021)
  - Fix Healthcheck issue when streaming recovers after a pause
  - Point to new toolkit with more bugfixes and updated dependencies

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 4.0.3 (TBD)
  - Added new `Update`-like method to redis split storage that return a proper error when something goes wrong
  - Added new `Update`-like method to redis segment storage that returns a summary of keys added/removed and a more informative error
+ - Fixed Latency bucketing unit
 
 4.0.2 (Jan 12, 2021)
  - Fix Healthcheck issue when streaming recovers after a pause

--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,10 @@
-4.0.3 (TBD)
+4.0.3 (Apr 18, 2022)
  - Added new `Update`-like method to redis split storage that return a proper error when something goes wrong
  - Added new `Update`-like method to redis segment storage that returns a summary of keys added/removed and a more informative error
  - Fixed Latency bucketing unit
+ - Redis now returns an error instead of panicking if fails to connect
 
-4.0.2 (Jan 12, 2021)
+4.0.2 (Jan 12, 2022)
  - Fix Healthcheck issue when streaming recovers after a pause
  - Point to new toolkit with more bugfixes and updated dependencies
 

--- a/storage/inmemory/telemetry_test.go
+++ b/storage/inmemory/telemetry_test.go
@@ -15,9 +15,9 @@ func TestTelemetryStorage(t *testing.T) {
 	telemetryStorage.RecordException(telemetry.Treatments)
 	telemetryStorage.RecordException(telemetry.Treatment)
 	telemetryStorage.RecordLatency(telemetry.Treatment, (1500 * time.Millisecond))
-	telemetryStorage.RecordLatency(telemetry.Treatment, (2000 * time.Millisecond))
-	telemetryStorage.RecordLatency(telemetry.Treatments, (3000 * time.Millisecond))
-	telemetryStorage.RecordLatency(telemetry.Treatments, (500 * time.Millisecond))
+	telemetryStorage.RecordLatency(telemetry.Treatment, (2500 * time.Millisecond))
+	telemetryStorage.RecordLatency(telemetry.Treatments, (18 * time.Millisecond))
+	telemetryStorage.RecordLatency(telemetry.Treatments, (26 * time.Millisecond))
 	telemetryStorage.RecordLatency(telemetry.TreatmentWithConfig, (800 * time.Millisecond))
 	telemetryStorage.RecordLatency(telemetry.TreatmentsWithConfig, (1000 * time.Millisecond))
 
@@ -30,16 +30,16 @@ func TestTelemetryStorage(t *testing.T) {
 		t.Error("Wrong result")
 	}
 	latencies := telemetryStorage.PopLatencies()
-	if latencies.Treatment[1] != 1 || latencies.Treatment[2] != 1 {
+	if latencies.Treatment[19] != 1 || latencies.Treatment[20] != 1 {
 		t.Error("Wrong result")
 	}
-	if latencies.Treatments[0] != 1 || latencies.Treatments[3] != 1 {
+	if latencies.Treatments[8] != 1 || latencies.Treatments[9] != 1 {
 		t.Error("Wrong result")
 	}
-	if latencies.TreatmentWithConfig[0] != 1 {
+	if latencies.TreatmentWithConfig[17] != 1 {
 		t.Error("Wrong result")
 	}
-	if latencies.TreatmentsWithConfig[0] != 1 {
+	if latencies.TreatmentsWithConfig[18] != 1 {
 		t.Error("Wrong result")
 	}
 	latencies = telemetryStorage.PopLatencies()
@@ -127,7 +127,7 @@ func TestTelemetryStorage(t *testing.T) {
 	}
 
 	httpLatencies := telemetryStorage.PopHTTPLatencies()
-	if httpLatencies.Splits[1] != 1 {
+	if httpLatencies.Splits[19] != 1 {
 		t.Errorf("Wrong result: %+v", httpLatencies)
 	}
 	httpLatencies = telemetryStorage.PopHTTPLatencies()

--- a/storage/redis/errors.go
+++ b/storage/redis/errors.go
@@ -1,0 +1,42 @@
+package redis
+
+import (
+	"errors"
+	"strings"
+)
+
+// Public errors
+var (
+	ErrChangeNumberUpdateFailed = errors.New("failed to update change number")
+)
+
+// UpdateError contains information on what splits failed to be added/removed and why
+type UpdateError struct {
+	FailedToAdd    map[string]error
+	FailedToRemove map[string]error
+}
+
+func (u *UpdateError) Error() string {
+	builder := strings.Builder{}
+	if len(u.FailedToAdd) > 0 {
+		builder.WriteString("failed to add the following splits [" + formatMapKeys(u.FailedToAdd) + "]")
+		if len(u.FailedToRemove) > 0 {
+			builder.WriteString(" and ")
+		}
+	}
+	if len(u.FailedToRemove) > 0 {
+		builder.WriteString("failed to remove the following splits [" + formatMapKeys(u.FailedToRemove) + "]")
+	}
+
+	return builder.String()
+}
+
+func formatMapKeys(in map[string]error) string {
+	slice := make([]string, 0, len(in))
+	for key := range in {
+		slice = append(slice, key)
+	}
+	return strings.Join(slice, ",")
+}
+
+var _ error = (*UpdateError)(nil)

--- a/storage/redis/errors.go
+++ b/storage/redis/errors.go
@@ -39,4 +39,26 @@ func formatMapKeys(in map[string]error) string {
 	return strings.Join(slice, ",")
 }
 
+// SegmentUpdateError includes possible failures when adding and removing keys from a segment
+type SegmentUpdateError struct {
+	FailureToAdd    error
+	FailureToRemove error
+}
+
+func (s *SegmentUpdateError) Error() string {
+	b := strings.Builder{}
+	if err := s.FailureToAdd; err != nil {
+		b.WriteString("failed to add segment keys: " + err.Error())
+		if s.FailureToRemove != nil {
+			b.WriteString(", and ")
+		}
+	}
+
+	if err := s.FailureToRemove; err != nil {
+		b.WriteString("failed to remove segment keys: " + err.Error())
+	}
+
+	return b.String()
+}
+
 var _ error = (*UpdateError)(nil)

--- a/storage/redis/redis_test.go
+++ b/storage/redis/redis_test.go
@@ -1,0 +1,24 @@
+package redis
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/splitio/go-split-commons/v4/conf"
+	"github.com/splitio/go-toolkit/v5/logging"
+)
+
+func TestRedisConnection(t *testing.T) {
+
+	client, err := NewRedisClient(&conf.RedisConfig{Host: "localhost", Port: 7658}, logging.NewLogger(nil))
+
+	if client != nil {
+		t.Error("client should be nil")
+	}
+
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) {
+		t.Errorf("expected a network error. Got: %T", err)
+	}
+}

--- a/storage/redis/segments.go
+++ b/storage/redis/segments.go
@@ -108,6 +108,13 @@ func (r *SegmentStorage) Update(name string, toAdd *set.ThreadUnsafeSet, toRemov
 	return nil
 }
 
+// Size returns the number of keys in a segment
+func (r *SegmentStorage) Size(name string) (int, error) {
+	res, err := r.client.SCard(strings.Replace(KeySegment, "{segment}", name, 1))
+	return int(res), err
+
+}
+
 // SegmentContainsKey returns true if the segment contains a specific key
 func (r *SegmentStorage) SegmentContainsKey(segmentName string, key string) (bool, error) {
 	segmentKey := strings.Replace(KeySegment, "{segment}", segmentName, 1)

--- a/storage/redis/segments_test.go
+++ b/storage/redis/segments_test.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/splitio/go-toolkit/v5/datastructures/set"
 	"github.com/splitio/go-toolkit/v5/logging"
@@ -123,4 +124,53 @@ func TestSegmentTill(t *testing.T) {
 	if till != 123456789 {
 		t.Error("Unexpected till")
 	}
+}
+
+func TestSegmentUpdateWithErrors(t *testing.T) {
+
+	var someError = errors.New("some")
+	mockClient := &mocks.MockClient{
+		SAddCall: func(key string, members ...interface{}) redis.Result {
+			return &mocks.MockResultOutput{
+				ResultCall: func() (int64, error) { return 1, someError },
+			}
+		},
+		SRemCall: func(key string, members ...interface{}) redis.Result {
+			return &mocks.MockResultOutput{
+				ResultCall: func() (int64, error) { return 0, nil },
+			}
+		},
+		SetCall: func(key string, value interface{}, expiration time.Duration) redis.Result {
+			return &mocks.MockResultOutput{
+				ErrCall: func() error { return nil },
+			}
+		},
+	}
+	mockRedis, _ := redis.NewPrefixedRedisClient(mockClient, "")
+	logger := logging.NewLogger(nil)
+
+	// type assertionr equired because the constructor for some reason is returning the basic interface type
+	segmentStorage := NewSegmentStorage(mockRedis, logger).(*SegmentStorage)
+
+	if added, removed, err := segmentStorage.UpdateWithSummary("seg", set.NewSet("key1", "key2"), set.NewSet(), 123); err != nil {
+		if suErr, ok := err.(*SegmentUpdateError); ok {
+			if suErr.FailureToAdd != someError {
+				t.Error("wrong error")
+			}
+
+			if e := suErr.FailureToRemove; e != nil {
+				t.Error("there should be no failures when removing elements. Got: ", e)
+			}
+		}
+
+		if added != 1 {
+			t.Error("added should be 1")
+		}
+		if removed != 0 {
+			t.Error("added should be 0")
+		}
+	} else {
+		t.Error("there should have been an error")
+	}
+
 }

--- a/storage/redis/splits.go
+++ b/storage/redis/splits.go
@@ -187,7 +187,7 @@ func (r *SplitStorage) UpdateWithErrors(toAdd []dtos.SplitDTO, toRemove []dtos.S
 			var s dtos.SplitDTO
 			err = json.Unmarshal([]byte(asStr), &s)
 			if err != nil {
-				r.logger.Warning("Update: ignoring split stored in redis taht cannot be deserialized for traffic-type updating purposes: ", asStr)
+				r.logger.Warning("Update: ignoring split stored in redis that cannot be deserialized for traffic-type updating purposes: ", asStr)
 				continue
 			}
 

--- a/storage/redis/splits_test.go
+++ b/storage/redis/splits_test.go
@@ -443,7 +443,7 @@ func TestTrafficTypeExists(t *testing.T) {
 	}
 }
 
-func TestUpdateWithErrors(t *testing.T) {
+func TestSplitUpdateWithErrors(t *testing.T) {
 	mockClient := &mocks.MockClient{
 		MGetCall: func(keys []string) redis.Result {
 			return &mocks.MockResultOutput{

--- a/storage/redis/telemetry_test.go
+++ b/storage/redis/telemetry_test.go
@@ -15,7 +15,7 @@ import (
 func TestRecordLatency(t *testing.T) {
 	call := 0
 	expectedKey := "someprefix.SPLITIO.telemetry.latencies"
-	exceptedField := "go-test-1/test/1.1.1.1/treatment/1"
+	exceptedField := "go-test-1/test/1.1.1.1/treatment/19"
 
 	mockedRedisClient := mocks.MockClient{
 		HIncrByCall: func(key, field string, value int64) redis.Result {

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -28,7 +28,8 @@ var latencyBuckets = [23]float64{
 
 // Bucket returns the bucket where the received latency falls
 func Bucket(latency int64) int {
-	floatLatency := float64(latency) / 1000 // Convert to millisencods
+
+	floatLatency := float64(latency)
 
 	index := 0
 	for index < len(latencyBuckets) && floatLatency > latencyBuckets[index] {

--- a/telemetry/metrics_test.go
+++ b/telemetry/metrics_test.go
@@ -2,19 +2,18 @@ package telemetry
 
 import (
 	"testing"
-	"time"
 )
 
 func TestBucket(t *testing.T) {
-	if Bucket(int64(500*time.Nanosecond)) != 0 {
+	if Bucket(int64(0)) != 0 {
 		t.Error("It should be zero")
 	}
 
-	if Bucket(int64(1500*time.Nanosecond)) != 1 {
-		t.Error("It should be one")
+	if Bucket(int64(2)) != 2 {
+		t.Error("It should be two")
 	}
 
-	if Bucket(int64(8000*time.Nanosecond)) != 6 {
+	if Bucket(int64(11)) != 6 {
 		t.Error("It should be 6")
 	}
 }


### PR DESCRIPTION
This PR adds a new method that's basically the same as the previous `RedisSplitStorage.Update` but instead of logging errors, it returns them. It uses a concrete implementation of error, to inform which split failed to be updated and why. This is needed for maintaining consistency between redis & the in-memory split-name cache, which is being added in split-sync for observability purposes