### PR TITLE
fix unnecessary warning

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+4.2.3 (Nov 30, 2022)
+ - Fix warning when trying to fetch a split by name that might noy yet exist in redis
+
 4.2.2 (Nov 14, 2022)
  - Fix redis cleanup to use `SPLITIO` prefix portion as well.
 

--- a/storage/redis/splits.go
+++ b/storage/redis/splits.go
@@ -180,7 +180,12 @@ func (r *SplitStorage) UpdateWithErrors(toAdd []dtos.SplitDTO, toRemove []dtos.S
 		for _, raw := range toUpdateRaw {
 			asStr, ok := raw.(string)
 			if !ok {
-				r.logger.Warning("Update: ignoring split stored in redis that cannot be parsed for traffic-type updating purposes: ", asStr)
+				if raw != nil { // object missing in redis
+					r.logger.Warning(fmt.Sprintf(
+						"Update: ignoring split stored in redis that cannot be parsed for traffic-type updating purposes: [%T] %+v",
+						raw, raw,
+					))
+				}
 				continue
 			}
 

--- a/storage/redis/splits.go
+++ b/storage/redis/splits.go
@@ -181,7 +181,7 @@ func (r *SplitStorage) UpdateWithErrors(toAdd []dtos.SplitDTO, toRemove []dtos.S
 			asStr, ok := raw.(string)
 			if !ok {
 				if raw != nil { // object missing in redis
-					r.logger.Warning(fmt.Sprintf(
+					r.logger.Debug(fmt.Sprintf(
 						"Update: ignoring split stored in redis that cannot be parsed for traffic-type updating purposes: [%T] %+v",
 						raw, raw,
 					))
@@ -192,7 +192,7 @@ func (r *SplitStorage) UpdateWithErrors(toAdd []dtos.SplitDTO, toRemove []dtos.S
 			var s dtos.SplitDTO
 			err = json.Unmarshal([]byte(asStr), &s)
 			if err != nil {
-				r.logger.Warning("Update: ignoring split stored in redis that cannot be deserialized for traffic-type updating purposes: ", asStr)
+				r.logger.Debug("Update: ignoring split stored in redis that cannot be deserialized for traffic-type updating purposes: ", asStr)
 				continue
 			}
 


### PR DESCRIPTION
Fix warning when trying to fetch a split by name that might noy yet exist in redis