### PR TITLE
[SDKS-6471] Synchronization logic and sha for splits

### DIFF
--- a/service/local/splitFetcher.go
+++ b/service/local/splitFetcher.go
@@ -261,7 +261,9 @@ func (s *FileSplitFetcher) Fetch(changeNumber int64, _ *service.FetchOptions) (*
 	case SplitFileFormatYAML:
 		splits = s.parseSplitsYAML(data)
 	case SplitFileFormatJSON:
-		return s.parseSplitsJson(data), nil
+		splitChange := s.parseSplitsJson(data)
+		splitChange.Since = splitChange.Till
+		return splitChange, nil
 	default:
 		return nil, fmt.Errorf("unsupported file format")
 

--- a/service/local/splitFetcher.go
+++ b/service/local/splitFetcher.go
@@ -294,7 +294,7 @@ func (s *FileSplitFetcher) Fetch(changeNumber int64, _ *service.FetchOptions) (*
 
 	// Get the SHA1 sum of the raw contents of the file, and compare it to the last one seen
 	// if it's equal, nothing has changed, return since == till
-	// otherwise, something changed, return till = since + 1  s
+	// otherwise, something changed, return till = since + 1
 	currH := sha1.New()
 	currH.Write(fileContents)
 	currSum := currH.Sum(nil)

--- a/service/local/splitFetcher.go
+++ b/service/local/splitFetcher.go
@@ -246,7 +246,7 @@ func (f *FileSplitFetcher) parseSplitsJson(data string) *dtos.SplitChangesDTO {
 	return &splitChangesDto
 }
 
-func (s *FileSplitFetcher) processSplitJson(data string, changeNumber int64) *dtos.SplitChangesDTO {
+func (s *FileSplitFetcher) processSplitJson(data string, changeNumber int64) (*dtos.SplitChangesDTO, error) {
 	var splitChangesDto dtos.SplitChangesDTO
 	splitChangesDto.Since = changeNumber
 	splitChangesDto.Till = changeNumber
@@ -254,18 +254,19 @@ func (s *FileSplitFetcher) processSplitJson(data string, changeNumber int64) *dt
 	splitsJson, err := json.Marshal(splitChange.Splits)
 	if err != nil {
 		s.logger.Error(fmt.Sprintf("error: %v", err))
-		return &splitChangesDto
+		s.logger.Error("ignoring file and defaulting to empty change")
+		return &splitChangesDto, nil
 	}
 	currH := sha1.New()
 	currH.Write(splitsJson)
 	currSum := currH.Sum(nil)
 	if bytes.Equal(currSum, s.lastHash) || splitChange.Till < changeNumber {
-		return &splitChangesDto
+		return &splitChangesDto, nil
 	}
 	s.lastHash = currSum
 	splitChange.Since = splitChange.Till
 	splitChange.Till++
-	return splitChange
+	return splitChange, nil
 }
 
 // Fetch parses the file and returns the appropriate structures
@@ -283,8 +284,7 @@ func (s *FileSplitFetcher) Fetch(changeNumber int64, _ *service.FetchOptions) (*
 	case SplitFileFormatYAML:
 		splits = s.parseSplitsYAML(data)
 	case SplitFileFormatJSON:
-		splitChange := s.processSplitJson(data, changeNumber)
-		return splitChange, nil
+		return s.processSplitJson(data, changeNumber)
 	default:
 		return nil, fmt.Errorf("unsupported file format")
 

--- a/service/local/splitFetcher.go
+++ b/service/local/splitFetcher.go
@@ -246,6 +246,28 @@ func (f *FileSplitFetcher) parseSplitsJson(data string) *dtos.SplitChangesDTO {
 	return &splitChangesDto
 }
 
+func (s *FileSplitFetcher) processSplitJson(data string, changeNumber int64) *dtos.SplitChangesDTO {
+	var splitChangesDto dtos.SplitChangesDTO
+	splitChangesDto.Since = changeNumber
+	splitChangesDto.Till = changeNumber
+	splitChange := s.parseSplitsJson(data)
+	splitsJson, err := json.Marshal(splitChange.Splits)
+	if err != nil {
+		s.logger.Error(fmt.Sprintf("error: %v", err))
+		return &splitChangesDto
+	}
+	currH := sha1.New()
+	currH.Write(splitsJson)
+	currSum := currH.Sum(nil)
+	if bytes.Equal(currSum, s.lastHash) || splitChange.Till < changeNumber {
+		return &splitChangesDto
+	}
+	s.lastHash = currSum
+	splitChange.Since = splitChange.Till
+	splitChange.Till++
+	return splitChange
+}
+
 // Fetch parses the file and returns the appropriate structures
 func (s *FileSplitFetcher) Fetch(changeNumber int64, _ *service.FetchOptions) (*dtos.SplitChangesDTO, error) {
 	fileContents, err := ioutil.ReadFile(s.splitFile)
@@ -261,8 +283,7 @@ func (s *FileSplitFetcher) Fetch(changeNumber int64, _ *service.FetchOptions) (*
 	case SplitFileFormatYAML:
 		splits = s.parseSplitsYAML(data)
 	case SplitFileFormatJSON:
-		splitChange := s.parseSplitsJson(data)
-		splitChange.Since = splitChange.Till
+		splitChange := s.processSplitJson(data, changeNumber)
 		return splitChange, nil
 	default:
 		return nil, fmt.Errorf("unsupported file format")
@@ -273,7 +294,7 @@ func (s *FileSplitFetcher) Fetch(changeNumber int64, _ *service.FetchOptions) (*
 
 	// Get the SHA1 sum of the raw contents of the file, and compare it to the last one seen
 	// if it's equal, nothing has changed, return since == till
-	// otherwise, something changed, return till = since + 1
+	// otherwise, something changed, return till = since + 1  s
 	currH := sha1.New()
 	currH.Write(fileContents)
 	currSum := currH.Sum(nil)

--- a/service/local/splitFetcher_test.go
+++ b/service/local/splitFetcher_test.go
@@ -148,6 +148,6 @@ func TestLocalSplitFetcherJsonTest1(t *testing.T) {
 	}
 
 	if len(res.Splits) != 0 {
-		t.Error("should have 7 splits. has: ", res.Splits)
+		t.Error("should have 0 split. has: ", res.Splits)
 	}
 }

--- a/service/local/splitFetcher_test.go
+++ b/service/local/splitFetcher_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/splitio/go-toolkit/v5/logging"
 )
 
+var jsonTest_1 = []byte(`{"splits":[{"trafficTypeName":"user","name":"SPLIT_1","trafficAllocation":100,"trafficAllocationSeed":-1780071202,"seed":-1442762199,"status":"ACTIVE","killed":false,"defaultTreatment":"off","changeNumber":1675443537882,"algo":2,"configurations":{},"conditions":[{"conditionType":"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType":"user","attribute":null},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData":null,"whitelistMatcherData":null,"unaryNumericMatcherData":null,"betweenMatcherData":null,"booleanMatcherData":null,"dependencyMatcherData":null,"stringMatcherData":null}]},"partitions":[{"treatment":"on","size":0},{"treatment":"off","size":100}],"label":"default rule"}]}],"since":-1,"till":-2}`)
+
 func TestLocalSplitFetcher(t *testing.T) {
 	file, err := ioutil.TempFile("", "localhost_test")
 	if err != nil {
@@ -100,7 +102,7 @@ func TestLocalSplitFetcherJson(t *testing.T) {
 		t.Error("fetching should not fail. Got: ", err)
 	}
 
-	if res.Since != -1 || res.Till != 1660326991072 {
+	if res.Since != 1660326991072 || res.Till != 1660326991073 {
 		t.Error("Wrong since/till. Got: ", res.Since, res.Till)
 	}
 
@@ -114,5 +116,38 @@ func TestLocalSplitFetcherJson(t *testing.T) {
 
 	if res.Splits[0].Configurations == nil {
 		t.Error("DTO mal formed")
+	}
+}
+
+func TestLocalSplitFetcherJsonTest1(t *testing.T) {
+	file, err := ioutil.TempFile("", "localhost_test-*.json")
+	if err != nil {
+		t.Error("should no fail to open temp file. Got: ", err)
+	}
+	defer os.Remove(file.Name())
+
+	if _, err := file.Write(jsonTest_1); err != nil {
+		t.Error("writing to the file should not fail")
+	}
+
+	if err := file.Sync(); err != nil {
+		t.Error("syncing the file should not fail")
+	}
+
+	logger := logging.NewLogger(nil)
+	fetcher := NewFileSplitFetcher(file.Name(), logger)
+
+	res, err := fetcher.Fetch(-1, &service.FetchOptions{})
+
+	if err != nil {
+		t.Error("fetching should not fail. Got: ", err)
+	}
+
+	if res.Since != -1 || res.Till != -1 {
+		t.Error("Wrong since/till. Got: ", res.Since, res.Till)
+	}
+
+	if len(res.Splits) != 0 {
+		t.Error("should have 7 splits. has: ", res.Splits)
 	}
 }


### PR DESCRIPTION
# GO SPLIT COMMONS

## What did you accomplish?

- New feature: Add synchronization logic and sha for splits, when the mode is json localhost.

## How do we test the changes introduced in this PR?

Added test cases in splitFetcher_test.