### PR TITLE
[SDKS-6449] Add error message when the files are not found

### DIFF
--- a/service/local/segmentFetcher.go
+++ b/service/local/segmentFetcher.go
@@ -76,6 +76,7 @@ func (s *FileSegmentFetcher) processSegmentJson(fileContents []byte, segmentName
 func (s *FileSegmentFetcher) Fetch(segmentName string, changeNumber int64, _ *service.FetchOptions) (*dtos.SegmentChangesDTO, error) {
 	fileContents, err := s.reader.ReadFile(fmt.Sprintf("%v/%v.json", s.segmentDirectory, segmentName))
 	if err != nil {
+		s.logger.Error(fmt.Sprintf("could not find the segmentChange file. error: %v", err))
 		return nil, err
 	}
 	return s.processSegmentJson(fileContents, segmentName, changeNumber)

--- a/service/local/splitFetcher.go
+++ b/service/local/splitFetcher.go
@@ -225,6 +225,7 @@ func (f *FileSplitFetcher) parseSplitsJson(data string) (*dtos.SplitChangesDTO, 
 func (s *FileSplitFetcher) processSplitJson(data string, changeNumber int64) (*dtos.SplitChangesDTO, error) {
 	splitChange, err := s.parseSplitsJson(data)
 	if err != nil {
+		s.logger.Error(fmt.Sprintf("could not find the splitChange file. error: %v", err))
 		return nil, err
 	}
 	// if the till is less than storage CN and different from the default till ignore the change


### PR DESCRIPTION
# GO SPLIT COMMONS

## What did you accomplish?

- New feature: Add an error message when the fetchers can't find the changes file.
