### PR TITLE
Add test cases for parse feature flag update

### DIFF
--- a/push/parser_test.go
+++ b/push/parser_test.go
@@ -60,8 +60,8 @@ func TestParseInstantFF(t *testing.T) {
 				Type:                  UpdateTypeSplitChange,
 				ChangeNumber:          123,
 				PreviousChangeNumber:  1,
-				CompressType:          &compressType,
-				FeatureFlagDefinition: &ffDefinition,
+				CompressType:          common.IntRef(compressType),
+				FeatureFlagDefinition: common.StringRef(ffDefinition),
 			})
 			mainJSON, _ := json.Marshal(genericData{
 				Timestamp: 123,
@@ -106,7 +106,7 @@ func TestParseInstantFFCompressTypeNil(t *testing.T) {
 				Type:                  UpdateTypeSplitChange,
 				ChangeNumber:          123,
 				PreviousChangeNumber:  1,
-				FeatureFlagDefinition: &ffDefinition,
+				FeatureFlagDefinition: common.StringRef(ffDefinition),
 			})
 			mainJSON, _ := json.Marshal(genericData{
 				Timestamp: 123,
@@ -153,8 +153,8 @@ func TestParseInstantFFCompressTypeGreaterTwo(t *testing.T) {
 				Type:                  UpdateTypeSplitChange,
 				ChangeNumber:          123,
 				PreviousChangeNumber:  1,
-				CompressType:          &compressType,
-				FeatureFlagDefinition: &ffDefinition,
+				CompressType:          common.IntRef(compressType),
+				FeatureFlagDefinition: common.StringRef(ffDefinition),
 			})
 			mainJSON, _ := json.Marshal(genericData{
 				Timestamp: 123,

--- a/push/parser_test.go
+++ b/push/parser_test.go
@@ -49,6 +49,147 @@ func TestParseSplitUpdate(t *testing.T) {
 	}
 }
 
+func TestParseInstantFF(t *testing.T) {
+	compressType := 0
+	ffDefinition := "feature flga definition"
+	event := &sseMocks.RawEventMock{
+		IDCall:    func() string { return "abc" },
+		EventCall: func() string { return SSEEventTypeMessage },
+		DataCall: func() string {
+			updateJSON, _ := json.Marshal(genericMessageData{
+				Type:                  UpdateTypeSplitChange,
+				ChangeNumber:          123,
+				PreviousChangeNumber:  1,
+				CompressType:          &compressType,
+				FeatureFlagDefinition: &ffDefinition,
+			})
+			mainJSON, _ := json.Marshal(genericData{
+				Timestamp: 123,
+				Data:      string(updateJSON),
+				Channel:   "sarasa_splits",
+			})
+			return string(mainJSON)
+		},
+		IsErrorCall: func() bool { return false },
+		IsEmptyCall: func() bool { return false },
+		RetryCall:   func() int64 { return 0 },
+	}
+
+	logger := logging.NewLogger(nil)
+	parser := &NotificationParserImpl{
+		logger: logger,
+		onSplitUpdate: func(u *SplitChangeUpdate) error {
+			if u.ChangeNumber() != 123 {
+				t.Error("change number should be 123. Is: ", u.changeNumber)
+			}
+			if u.Channel() != "sarasa_splits" {
+				t.Error("channel should be sarasa_splits. Is:", u.channel)
+			}
+			if *u.compressType != 0 {
+				t.Error("compress type should be 0")
+			}
+			return nil
+		},
+	}
+
+	if status, err := parser.ParseAndForward(event); status != nil || err != nil {
+		t.Error("no error should have been returned. Got: ", err)
+	}
+}
+func TestParseInstantFFCompressTypeNil(t *testing.T) {
+	ffDefinition := "feature flga definition"
+	event := &sseMocks.RawEventMock{
+		IDCall:    func() string { return "abc" },
+		EventCall: func() string { return SSEEventTypeMessage },
+		DataCall: func() string {
+			updateJSON, _ := json.Marshal(genericMessageData{
+				Type:                  UpdateTypeSplitChange,
+				ChangeNumber:          123,
+				PreviousChangeNumber:  1,
+				FeatureFlagDefinition: &ffDefinition,
+			})
+			mainJSON, _ := json.Marshal(genericData{
+				Timestamp: 123,
+				Data:      string(updateJSON),
+				Channel:   "sarasa_splits",
+			})
+			return string(mainJSON)
+		},
+		IsErrorCall: func() bool { return false },
+		IsEmptyCall: func() bool { return false },
+		RetryCall:   func() int64 { return 0 },
+	}
+
+	logger := logging.NewLogger(nil)
+	parser := &NotificationParserImpl{
+		logger: logger,
+		onSplitUpdate: func(u *SplitChangeUpdate) error {
+			if u.ChangeNumber() != 123 {
+				t.Error("change number should be 123. Is: ", u.changeNumber)
+			}
+			if u.Channel() != "sarasa_splits" {
+				t.Error("channel should be sarasa_splits. Is:", u.channel)
+			}
+			if u.compressType != nil {
+				t.Error("compress type should be nil")
+			}
+			return nil
+		},
+	}
+
+	if status, err := parser.ParseAndForward(event); status != nil || err != nil {
+		t.Error("no error should have been returned. Got: ", err)
+	}
+}
+
+func TestParseInstantFFCompressTypeGreaterTwo(t *testing.T) {
+	compressType := 3
+	ffDefinition := "feature flga definition"
+	event := &sseMocks.RawEventMock{
+		IDCall:    func() string { return "abc" },
+		EventCall: func() string { return SSEEventTypeMessage },
+		DataCall: func() string {
+			updateJSON, _ := json.Marshal(genericMessageData{
+				Type:                  UpdateTypeSplitChange,
+				ChangeNumber:          123,
+				PreviousChangeNumber:  1,
+				CompressType:          &compressType,
+				FeatureFlagDefinition: &ffDefinition,
+			})
+			mainJSON, _ := json.Marshal(genericData{
+				Timestamp: 123,
+				Data:      string(updateJSON),
+				Channel:   "sarasa_splits",
+			})
+			return string(mainJSON)
+		},
+		IsErrorCall: func() bool { return false },
+		IsEmptyCall: func() bool { return false },
+		RetryCall:   func() int64 { return 0 },
+	}
+
+	logger := logging.NewLogger(nil)
+	parser := &NotificationParserImpl{
+		logger: logger,
+		onSplitUpdate: func(u *SplitChangeUpdate) error {
+			if u.ChangeNumber() != 123 {
+				t.Error("change number should be 123. Is: ", u.changeNumber)
+			}
+			if u.Channel() != "sarasa_splits" {
+				t.Error("channel should be sarasa_splits. Is:", u.channel)
+			}
+			if u.compressType != nil {
+				t.Error("compress type should be nil")
+			}
+			return nil
+		},
+	}
+
+	if status, err := parser.ParseAndForward(event); status != nil || err != nil {
+		t.Error("no error should have been returned. Got: ", err)
+	}
+}
+
 func TestParseSplitKill(t *testing.T) {
 	event := &sseMocks.RawEventMock{
 		IDCall:    func() string { return "abc" },


### PR DESCRIPTION
# GO SPLIT COMMONS

## What did you accomplish?

- Add test cases
- Removed const compressType because y declared in the toolkit

## How do we test the changes introduced in this PR?

## Extra Notes