### PR TITLE
[SDKS-7686] Log 414 error when fetch feature flags

### DIFF
--- a/synchronizer/worker/split/split.go
+++ b/synchronizer/worker/split/split.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	matcherTypeInSegment           = "IN_SEGMENT"
-	scRequestURITooLong            = 214
+	scRequestURITooLong            = 414
 	onDemandFetchBackoffBase       = int64(10)        // backoff base starting at 10 seconds
 	onDemandFetchBackoffMaxWait    = 60 * time.Second //  don't sleep for more than 1 minute
 	onDemandFetchBackoffMaxRetries = 10

--- a/synchronizer/worker/split/split.go
+++ b/synchronizer/worker/split/split.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	matcherTypeInSegment           = "IN_SEGMENT"
+	scRequestURITooLong            = 214
 	onDemandFetchBackoffBase       = int64(10)        // backoff base starting at 10 seconds
 	onDemandFetchBackoffMaxWait    = 60 * time.Second //  don't sleep for more than 1 minute
 	onDemandFetchBackoffMaxRetries = 10
@@ -102,6 +103,9 @@ func (s *UpdaterImpl) fetchUntil(fetchOptions *service.FetchOptions, till *int64
 		splits, err = s.splitFetcher.Fetch(currentSince, fetchOptions)
 		if err != nil {
 			if httpError, ok := err.(*dtos.HTTPError); ok {
+				if httpError.Code == scRequestURITooLong {
+					s.logger.Error("SDK Initialization, the amount of flag sets provided are big causing uri length error.")
+				}
 				s.runtimeTelemetry.RecordSyncError(telemetry.SplitSync, httpError.Code)
 			}
 			break


### PR DESCRIPTION
# GO SPLIT COMMONS

## What did you accomplish?

- New feature: log error "SDK Initialization, the amount of flag sets provided are big causing uri length error." when is 414 code.

## How do we test the changes introduced in this PR?

## Extra Notes
