### PR TITLE
Update evaluator and add test cases

### DIFF
--- a/dtos/rulebasedsegment.go
+++ b/dtos/rulebasedsegment.go
@@ -18,11 +18,11 @@ type RuleBasedSegmentDTO struct {
 }
 
 type ExcludedDTO struct {
-	Keys     []string              `json:"keys"`
-	Segments []ExcluededSegmentDTO `json:"segments"`
+	Keys     []string             `json:"keys"`
+	Segments []ExcludedSegmentDTO `json:"segments"`
 }
 
-type ExcluededSegmentDTO struct {
+type ExcludedSegmentDTO struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 }

--- a/engine/evaluator/evaluator.go
+++ b/engine/evaluator/evaluator.go
@@ -38,24 +38,27 @@ type Results struct {
 
 // Evaluator struct is the main evaluator
 type Evaluator struct {
-	splitStorage   storage.SplitStorageConsumer
-	segmentStorage storage.SegmentStorageConsumer
-	eng            *engine.Engine
-	logger         logging.LoggerInterface
+	splitStorage            storage.SplitStorageConsumer
+	segmentStorage          storage.SegmentStorageConsumer
+	ruleBasedSegmentStorage storage.RuleBasedSegmentStorageConsumer
+	eng                     *engine.Engine
+	logger                  logging.LoggerInterface
 }
 
 // NewEvaluator instantiates an Evaluator struct and returns a reference to it
 func NewEvaluator(
 	splitStorage storage.SplitStorageConsumer,
 	segmentStorage storage.SegmentStorageConsumer,
+	ruleBasedSegmentStorage storage.RuleBasedSegmentStorageConsumer,
 	eng *engine.Engine,
 	logger logging.LoggerInterface,
 ) *Evaluator {
 	return &Evaluator{
-		splitStorage:   splitStorage,
-		segmentStorage: segmentStorage,
-		eng:            eng,
-		logger:         logger,
+		splitStorage:            splitStorage,
+		segmentStorage:          segmentStorage,
+		eng:                     eng,
+		logger:                  logger,
+		ruleBasedSegmentStorage: ruleBasedSegmentStorage,
 	}
 }
 
@@ -69,6 +72,7 @@ func (e *Evaluator) evaluateTreatment(key string, bucketingKey string, featureFl
 	ctx := injection.NewContext()
 	ctx.AddDependency("segmentStorage", e.segmentStorage)
 	ctx.AddDependency("evaluator", e)
+	ctx.AddDependency("ruleBasedSegmentStorage", e.ruleBasedSegmentStorage)
 
 	split := grammar.NewSplit(splitDto, ctx, e.logger)
 

--- a/engine/evaluator/evaluator_test.go
+++ b/engine/evaluator/evaluator_test.go
@@ -235,6 +235,7 @@ func TestSplitWithoutConfigurations(t *testing.T) {
 		&mockStorage{},
 		nil,
 		nil,
+		nil,
 		logger)
 
 	key := "test"
@@ -254,6 +255,7 @@ func TestSplitWithtConfigurations(t *testing.T) {
 
 	evaluator := NewEvaluator(
 		&mockStorage{},
+		nil,
 		nil,
 		nil,
 		logger)
@@ -277,6 +279,7 @@ func TestSplitWithtConfigurationsButKilled(t *testing.T) {
 		&mockStorage{},
 		nil,
 		nil,
+		nil,
 		logger)
 
 	key := "test"
@@ -298,6 +301,7 @@ func TestSplitWithConfigurationsButKilledWithConfigsOnDefault(t *testing.T) {
 		&mockStorage{},
 		nil,
 		nil,
+		nil,
 		logger)
 
 	key := "test"
@@ -317,6 +321,7 @@ func TestMultipleEvaluations(t *testing.T) {
 
 	evaluator := NewEvaluator(
 		&mockStorage{},
+		nil,
 		nil,
 		nil,
 		logger)
@@ -374,6 +379,7 @@ func TestNoConditionMatched(t *testing.T) {
 		splitStorage,
 		nil,
 		nil,
+		nil,
 		logger)
 
 	key := "test"
@@ -417,6 +423,7 @@ func TestEvaluationByFlagSets(t *testing.T) {
 
 	evaluator := NewEvaluator(
 		mockedStorage,
+		nil,
 		nil,
 		nil,
 		logger)
@@ -479,6 +486,7 @@ func TestEvaluationByFlagSetsASetEmpty(t *testing.T) {
 
 	evaluator := NewEvaluator(
 		mockedStorage,
+		nil,
 		nil,
 		nil,
 		logger)

--- a/engine/grammar/dependency_test/dependency_test.go
+++ b/engine/grammar/dependency_test/dependency_test.go
@@ -116,6 +116,7 @@ func TestDependencyMatcher(t *testing.T) {
 		},
 	}, nil, 1)
 	segmentStorage := mutexmap.NewMMSegmentStorage()
+	ruleBasedSegmentStorage := mutexmap.NewRuleBasedSegmentsStorage()
 
 	ctx := injection.NewContext()
 	ctx.AddDependency(
@@ -123,6 +124,7 @@ func TestDependencyMatcher(t *testing.T) {
 		evaluator.NewEvaluator(
 			splitStorage,
 			segmentStorage,
+			ruleBasedSegmentStorage,
 			engine.NewEngine(logger),
 			logger,
 		),

--- a/engine/grammar/inrulebasedsegment_test.go
+++ b/engine/grammar/inrulebasedsegment_test.go
@@ -44,7 +44,7 @@ func TestInRuleBasedSegmentMatcher_Match(t *testing.T) {
 			segment: &dtos.RuleBasedSegmentDTO{
 				Excluded: dtos.ExcludedDTO{
 					Keys:     []string{"key1", "key2"},
-					Segments: []dtos.ExcluededSegmentDTO{},
+					Segments: []dtos.ExcludedSegmentDTO{},
 				},
 			},
 			expectedResult: false,
@@ -55,7 +55,7 @@ func TestInRuleBasedSegmentMatcher_Match(t *testing.T) {
 			segment: &dtos.RuleBasedSegmentDTO{
 				Excluded: dtos.ExcludedDTO{
 					Keys: []string{},
-					Segments: []dtos.ExcluededSegmentDTO{
+					Segments: []dtos.ExcludedSegmentDTO{
 						{Name: "segment2", Type: dtos.TypeStandard},
 					},
 				},
@@ -68,7 +68,7 @@ func TestInRuleBasedSegmentMatcher_Match(t *testing.T) {
 			segment: &dtos.RuleBasedSegmentDTO{
 				Excluded: dtos.ExcludedDTO{
 					Keys: []string{},
-					Segments: []dtos.ExcluededSegmentDTO{
+					Segments: []dtos.ExcludedSegmentDTO{
 						{Name: "segment3", Type: dtos.TypeRuleBased},
 					},
 				},

--- a/service/local/splitFetcher.go
+++ b/service/local/splitFetcher.go
@@ -26,7 +26,8 @@ type FileSplitFetcher struct {
 	lastHash   []byte
 	lastHashRB []byte
 	logger     logging.LoggerInterface
-	mutex      sync.Mutex
+	mutexFF    sync.Mutex
+	mutexRB    sync.Mutex
 }
 
 // NewFileSplitFetcher returns a new instance of LocalFileSplitFetcher
@@ -36,7 +37,8 @@ func NewFileSplitFetcher(splitFile string, logger logging.LoggerInterface, fileF
 		fileFormat: fileFormat,
 		logger:     logger,
 		reader:     NewFileReader(),
-		mutex:      sync.Mutex{},
+		mutexFF:    sync.Mutex{},
+		mutexRB:    sync.Mutex{},
 	}
 }
 
@@ -242,8 +244,8 @@ func (s *FileSplitFetcher) processSplitJson(data string, changeNumber int64) (*d
 	currH.Write(splitsJson)
 	// calculate the json sha
 	currSum := currH.Sum(nil)
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	s.mutexFF.Lock()
+	defer s.mutexFF.Unlock()
 	//if sha exist and is equal to before sha, or if till is equal to default till returns the same splitChange with till equals to storage CN
 	if bytes.Equal(currSum, s.lastHash) || splitChange.FeatureFlags.Till == defaultTill {
 		s.lastHash = currSum
@@ -260,8 +262,8 @@ func (s *FileSplitFetcher) processSplitJson(data string, changeNumber int64) (*d
 		currHRB.Write(ruleBasedJson)
 		// calculate the json sha
 		currSumRB := currHRB.Sum(nil)
-		s.mutex.Lock()
-		defer s.mutex.Unlock()
+		s.mutexRB.Lock()
+		defer s.mutexRB.Unlock()
 		//if sha exist and is equal to before sha, or if till is equal to default till returns the same splitChange with till equals to storage CN
 		if bytes.Equal(currSumRB, s.lastHashRB) || splitChange.RuleBasedSegments.Till == defaultTill {
 			s.lastHashRB = currSumRB

--- a/service/local/splitFetcher_test.go
+++ b/service/local/splitFetcher_test.go
@@ -277,6 +277,33 @@ func TestLocalSplitFetcherJson(t *testing.T) {
 	}
 }
 
+func TestLocalSplitFetcherJsonWithRbs(t *testing.T) {
+	logger := logging.NewLogger(nil)
+
+	fetcher := NewFileSplitFetcher("../../testdata/splitChange_mock_1.json", logger, SplitFileFormatJSON)
+
+	res, err := fetcher.Fetch(service.MakeFlagRequestParams().WithChangeNumber(-1))
+	if err != nil {
+		t.Error("fetching should not fail. Got: ", err)
+	}
+
+	if res.FeatureFlags.Since != 10 || res.FeatureFlags.Till != 10 {
+		t.Error("Wrong since/till. Got: ", res.FeatureFlags.Since, res.FeatureFlags.Till)
+	}
+
+	if len(res.FeatureFlags.Splits) != 1 {
+		t.Error("should have 1 splits. has: ", res.FeatureFlags.Splits)
+	}
+
+	if res.FeatureFlags.Splits[0].Name != "rbs_split" {
+		t.Error("DTO mal formed")
+	}
+
+	if res.FeatureFlags.Splits[0].Configurations == nil {
+		t.Error("DTO mal formed")
+	}
+}
+
 func TestLocalSplitFetcherJsonTest1(t *testing.T) {
 	file, err := ioutil.TempFile("", "localhost_test-*.json")
 	if err != nil {

--- a/storage/inmemory/mutexmap/rulebasedsegment_test.go
+++ b/storage/inmemory/mutexmap/rulebasedsegment_test.go
@@ -34,7 +34,7 @@ func TestRuleBasedSegmentsStorage(t *testing.T) {
 			},
 		},
 		Excluded: dtos.ExcludedDTO{
-			Segments: []dtos.ExcluededSegmentDTO{
+			Segments: []dtos.ExcludedSegmentDTO{
 				{
 					Name: "excluded1",
 					Type: dtos.TypeStandard,
@@ -107,7 +107,7 @@ func TestRuleBasedSegmentsStorageEdgeCases(t *testing.T) {
 	ruleBased := dtos.RuleBasedSegmentDTO{
 		Name: "rule1",
 		Excluded: dtos.ExcludedDTO{
-			Segments: []dtos.ExcluededSegmentDTO{
+			Segments: []dtos.ExcludedSegmentDTO{
 				{
 					Name: "excluded1",
 					Type: dtos.TypeStandard,

--- a/storage/inmemory/mutexmap/splits.go
+++ b/storage/inmemory/mutexmap/splits.go
@@ -193,7 +193,7 @@ func (m *MMSplitStorage) SegmentNames() *set.ThreadUnsafeSet {
 	for _, split := range m.data {
 		for _, condition := range split.Conditions {
 			for _, matcher := range condition.MatcherGroup.Matchers {
-				if matcher.UserDefinedSegment != nil {
+				if matcher.UserDefinedSegment != nil && matcher.MatcherType != "IN_RULE_BASED_SEGMENT" {
 					segments.Add(matcher.UserDefinedSegment.SegmentName)
 				}
 

--- a/testdata/splitChange_mock_1.json
+++ b/testdata/splitChange_mock_1.json
@@ -1,0 +1,143 @@
+
+{
+  "ff": {
+    "s": 10,
+    "t": 10,
+    "d": [
+      {
+        "changeNumber": 10,
+        "trafficTypeName": "user",
+        "name": "rbs_split",
+        "trafficAllocation": 100,
+        "trafficAllocationSeed": 1828377380,
+        "seed": -286617921,
+        "status": "ACTIVE",
+        "killed": false,
+        "defaultTreatment": "off",
+        "algo": 2,
+        "conditions": [
+          {
+            "conditionType": "ROLLOUT",
+            "matcherGroup": {
+              "combiner": "AND",
+              "matchers": [
+                {
+                  "keySelector": {
+                    "trafficType": "user"
+                  },
+                  "matcherType": "IN_RULE_BASED_SEGMENT",
+                  "negate": false,
+                  "userDefinedSegmentMatcherData": {
+                    "segmentName": "rbs_test"
+                  }
+                }
+              ]
+            },
+            "partitions": [
+              {
+                "treatment": "on",
+                "size": 100
+              },
+              {
+                "treatment": "off",
+                "size": 0
+              }
+            ],
+            "label": "in rule based segment rbs_test"
+          },
+          {
+            "conditionType": "ROLLOUT",
+            "matcherGroup": {
+              "combiner": "AND",
+              "matchers": [
+                {
+                  "keySelector": {
+                    "trafficType": "user"
+                  },
+                  "matcherType": "ALL_KEYS",
+                  "negate": false
+                }
+              ]
+            },
+            "partitions": [
+              {
+                "treatment": "on",
+                "size": 0
+              },
+              {
+                "treatment": "off",
+                "size": 100
+              }
+            ],
+            "label": "default rule"
+          }
+        ],
+        "configurations": {},
+        "sets": [],
+        "impressionsDisabled": false
+      }
+    ]
+  },
+  "rbs": {
+    "s": 5,
+    "t": 5,
+    "d": [
+      {
+        "changeNumber": 5,
+        "name": "rbs_test",
+        "status": "ACTIVE",
+        "trafficTypeName": "user",
+        "excluded": {
+          "keys": [
+            "key22"
+          ],
+          "segments": [
+            {
+              "name": "segment_test",
+              "type": "standard"
+            }
+          ]
+        },
+        "conditions": [
+          {
+            "matcherGroup": {
+              "combiner": "AND",
+              "matchers": [
+                {
+                  "keySelector": {
+                    "trafficType": "user",
+                    "attribute": "email"
+                  },
+                  "matcherType": "ENDS_WITH",
+                  "negate": false,
+                  "whitelistMatcherData": {
+                    "whitelist": [
+                      "@split.io"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "matcherGroup": {
+              "combiner": "AND",
+              "matchers": [
+                {
+                  "keySelector": {
+                    "trafficType": "user"
+                  },
+                  "matcherType": "IN_SEGMENT",
+                  "negate": false,
+                  "userDefinedSegmentMatcherData": {
+                    "segmentName": "regular_segment"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# GO SPLIT COMMONS

## What did you accomplish?
- Updated evaluator to map the rule-based segment storage
- Updated split fetcher to have a sync mutex for rule-based
- Updated splits to filter also by rule-based segment when get segment names

## How do we test the changes introduced in this PR?
 Updated and added test cases in:
- evaluator_test.go
- inrulebasedsegment_test.go
- splitFetcher_test.go
- rulebasedsegment_test.go

## Extra Notes
