### PR TITLE
[FME-9998] Add storages for in segment, in large segment and rule-based segment

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -95,7 +95,7 @@ func TestTreatmentOnTrafficAllocation1(t *testing.T) {
 		},
 	}
 
-	split := grammar.NewSplit(&splitDTO, nil, logger, grammar.NewRuleBuilder(nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger))
+	split := grammar.NewSplit(&splitDTO, nil, logger, grammar.NewRuleBuilder(nil, nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger))
 
 	eng := Engine{}
 	eng.logger = logger
@@ -144,7 +144,7 @@ func TestTreatmentOnTrafficAllocation99(t *testing.T) {
 		},
 	}
 
-	split := grammar.NewSplit(&splitDTO, nil, logger, grammar.NewRuleBuilder(nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger))
+	split := grammar.NewSplit(&splitDTO, nil, logger, grammar.NewRuleBuilder(nil, nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger))
 
 	eng := Engine{}
 	eng.logger = logger
@@ -246,7 +246,7 @@ func TestEvaluations(t *testing.T) {
 		t.Error("Data was not added for testing consistency")
 	}
 
-	split := grammar.NewSplit(&splitDTO, nil, logger, grammar.NewRuleBuilder(nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger))
+	split := grammar.NewSplit(&splitDTO, nil, logger, grammar.NewRuleBuilder(nil, nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger))
 
 	eng := Engine{}
 	eng.logger = logger
@@ -276,7 +276,7 @@ func TestNoConditionMatched(t *testing.T) {
 		Conditions:            []dtos.ConditionDTO{},
 	}
 
-	split := grammar.NewSplit(&splitDTO, nil, logger, grammar.NewRuleBuilder(nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger))
+	split := grammar.NewSplit(&splitDTO, nil, logger, grammar.NewRuleBuilder(nil, nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger))
 
 	eng := Engine{}
 	eng.logger = logger

--- a/engine/evaluator/evaluator_test.go
+++ b/engine/evaluator/evaluator_test.go
@@ -246,6 +246,7 @@ func TestSplitWithoutConfigurations(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		logger,
 		syncProxyFeatureFlagsRules,
 		syncProxyRuleBasedSegmentRules)
@@ -267,6 +268,7 @@ func TestSplitWithtConfigurations(t *testing.T) {
 
 	evaluator := NewEvaluator(
 		&mockStorage{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -294,6 +296,7 @@ func TestSplitWithtConfigurationsButKilled(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		logger,
 		syncProxyFeatureFlagsRules,
 		syncProxyRuleBasedSegmentRules)
@@ -318,6 +321,7 @@ func TestSplitWithConfigurationsButKilledWithConfigsOnDefault(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		logger,
 		syncProxyFeatureFlagsRules,
 		syncProxyRuleBasedSegmentRules)
@@ -339,6 +343,7 @@ func TestMultipleEvaluations(t *testing.T) {
 
 	evaluator := NewEvaluator(
 		&mockStorage{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -400,6 +405,7 @@ func TestNoConditionMatched(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		logger,
 		syncProxyFeatureFlagsRules,
 		syncProxyRuleBasedSegmentRules)
@@ -445,6 +451,7 @@ func TestEvaluationByFlagSets(t *testing.T) {
 
 	evaluator := NewEvaluator(
 		mockedStorage,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -510,6 +517,7 @@ func TestEvaluationByFlagSetsASetEmpty(t *testing.T) {
 
 	evaluator := NewEvaluator(
 		mockedStorage,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/engine/grammar/allkeys_test.go
+++ b/engine/grammar/allkeys_test.go
@@ -14,7 +14,7 @@ func TestAllKeysMatcher(t *testing.T) {
 	dto := &dtos.MatcherDTO{
 		MatcherType: "ALL_KEYS",
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/allofset_test.go
+++ b/engine/grammar/allofset_test.go
@@ -21,7 +21,7 @@ func TestAllOfSetMatcher(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/anyofset_test.go
+++ b/engine/grammar/anyofset_test.go
@@ -21,7 +21,7 @@ func TestAnyOfSetMatcher(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/between_test.go
+++ b/engine/grammar/between_test.go
@@ -23,7 +23,7 @@ func TestBetweenMatcherInt(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -71,7 +71,7 @@ func TestBetweenMatcherDatetime(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/boolean_test.go
+++ b/engine/grammar/boolean_test.go
@@ -20,7 +20,7 @@ func TestBooleanMatcherTrue(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestBooleanMatcherFalse(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/condition_test.go
+++ b/engine/grammar/condition_test.go
@@ -47,7 +47,7 @@ func TestConditionWrapperObject(t *testing.T) {
 		},
 	}
 
-	wrapped, err := NewCondition(&condition1, logger, NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
+	wrapped, err := NewCondition(&condition1, logger, NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
 
 	if err != nil {
 		t.Error("err should be nil")
@@ -118,7 +118,7 @@ func TestAnotherWrapper(t *testing.T) {
 		},
 	}
 
-	wrapped, err := NewCondition(&condition1, logger, NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
+	wrapped, err := NewCondition(&condition1, logger, NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
 	if err != nil {
 		t.Error("err should be nil")
 	}
@@ -188,7 +188,7 @@ func TestConditionUnsupportedMatcherWrapperObject(t *testing.T) {
 		},
 	}
 
-	_, err := NewCondition(&condition1, logger, NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
+	_, err := NewCondition(&condition1, logger, NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
 
 	if err == nil {
 		t.Error("err should not be nil")
@@ -230,7 +230,7 @@ func TestConditionMatcherWithNilStringWrapperObject(t *testing.T) {
 		},
 	}
 
-	condition, err := NewCondition(&condition1, logger, NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
+	condition, err := NewCondition(&condition1, logger, NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
 
 	if err != nil {
 		t.Error("err should be nil")
@@ -309,7 +309,7 @@ func TestNewRBCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cond, err := NewRBCondition(tt.condition, logger, NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
+			cond, err := NewRBCondition(tt.condition, logger, NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/engine/grammar/contains_test.go
+++ b/engine/grammar/contains_test.go
@@ -21,7 +21,7 @@ func TestContainsString(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/dependency_test/dependency_test.go
+++ b/engine/grammar/dependency_test/dependency_test.go
@@ -126,6 +126,7 @@ func TestDependencyMatcher(t *testing.T) {
 	}, nil, 1)
 	segmentStorage := mutexmap.NewMMSegmentStorage()
 	ruleBasedSegmentStorage := mutexmap.NewRuleBasedSegmentsStorage()
+	largeSegmentStorage := mutexmap.NewLargeSegmentsStorage()
 
 	ctx := injection.NewContext()
 	ctx.AddDependency(
@@ -134,13 +135,14 @@ func TestDependencyMatcher(t *testing.T) {
 			splitStorage,
 			segmentStorage,
 			ruleBasedSegmentStorage,
+			largeSegmentStorage,
 			engine.NewEngine(logger),
 			logger,
 			syncProxyFeatureFlagsRules,
 			syncProxyRuleBasedSegmentRules,
 		),
 	)
-	ruleBuilder := grammar.NewRuleBuilder(ctx, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := grammar.NewRuleBuilder(ctx, nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -253,7 +255,7 @@ func TestDependencyMatcherWithBucketingKey(t *testing.T) {
 	ctx := injection.NewContext()
 	ctx.AddDependency("evaluator", &mockEvaluator{expectedBucketingKey: "bucketingKey_1", t: t})
 
-	ruleBuilder := grammar.NewRuleBuilder(ctx, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := grammar.NewRuleBuilder(ctx, nil, nil, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/endswith_test.go
+++ b/engine/grammar/endswith_test.go
@@ -21,7 +21,7 @@ func TestEndsWith(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/equalto_test.go
+++ b/engine/grammar/equalto_test.go
@@ -22,7 +22,7 @@ func TestEqualToMatcherInt(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -61,7 +61,7 @@ func TestEqualToMatcherDatetime(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/equaltoset_test.go
+++ b/engine/grammar/equaltoset_test.go
@@ -21,7 +21,7 @@ func TestEqualToSetMatcher(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/gtoet_test.go
+++ b/engine/grammar/gtoet_test.go
@@ -23,7 +23,7 @@ func TestGreaterThanOrEqualToMatcherInt(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -63,7 +63,7 @@ func TestGreaterThanOrEqualToMatcherDatetime(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/inlargesegment.go
+++ b/engine/grammar/inlargesegment.go
@@ -9,13 +9,14 @@ import (
 // InLargeSegmentMatcher matches if the key passed is in the large segment which the matcher was constructed with
 type InLargeSegmentMatcher struct {
 	Matcher
-	name string
+	name                string
+	largeSegmentStorage storage.LargeSegmentStorageConsumer
 }
 
 // Match returns true if the key is in the matcher's segment
 func (m *InLargeSegmentMatcher) Match(key string, attributes map[string]interface{}, bucketingKey *string) bool {
-	storage, ok := m.Context.Dependency("largeSegmentStorage").(storage.LargeSegmentStorageConsumer)
-	if !ok {
+	storage := m.largeSegmentStorage
+	if storage == nil {
 		m.logger.Error("InLargeSegmentMatcher: Unable to retrieve large segment storage!")
 		return false
 	}
@@ -28,12 +29,13 @@ func (m *InLargeSegmentMatcher) Match(key string, attributes map[string]interfac
 }
 
 // NewInLargeSegmentMatcher instantiates a new InLargeSegmentMatcher
-func NewInLargeSegmentMatcher(negate bool, name string, attributeName *string) *InLargeSegmentMatcher {
+func NewInLargeSegmentMatcher(negate bool, name string, attributeName *string, largeSegmentStorage storage.LargeSegmentStorageConsumer) *InLargeSegmentMatcher {
 	return &InLargeSegmentMatcher{
 		Matcher: Matcher{
 			negate:        negate,
 			attributeName: attributeName,
 		},
-		name: name,
+		name:                name,
+		largeSegmentStorage: largeSegmentStorage,
 	}
 }

--- a/engine/grammar/inlargesegment_test.go
+++ b/engine/grammar/inlargesegment_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/splitio/go-split-commons/v6/dtos"
 	"github.com/splitio/go-split-commons/v6/storage/inmemory/mutexmap"
-	"github.com/splitio/go-toolkit/v5/injection"
 	"github.com/splitio/go-toolkit/v5/logging"
 )
 
@@ -35,10 +34,7 @@ func TestInLargeSegmentMatcher(t *testing.T) {
 	segmentStorage := mutexmap.NewLargeSegmentsStorage()
 	segmentStorage.Update(lsName, lsKeys, 123)
 
-	ctx := injection.NewContext()
-	ctx.AddDependency("largeSegmentStorage", segmentStorage)
-
-	ruleBuilder := NewRuleBuilder(ctx, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, segmentStorage, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/insegment.go
+++ b/engine/grammar/insegment.go
@@ -9,18 +9,19 @@ import (
 // InSegmentMatcher matches if the key passed is in the segment which the matcher was constructed with
 type InSegmentMatcher struct {
 	Matcher
-	segmentName string
+	segmentName    string
+	segmentStorage storage.SegmentStorageConsumer
 }
 
 // Match returns true if the key is in the matcher's segment
 func (m *InSegmentMatcher) Match(key string, attributes map[string]interface{}, bucketingKey *string) bool {
-	segmentStorage, ok := m.Context.Dependency("segmentStorage").(storage.SegmentStorageConsumer)
-	if !ok {
+	storage := m.segmentStorage
+	if storage == nil {
 		m.logger.Error("InSegmentMatcher: Unable to retrieve segment storage!")
 		return false
 	}
 
-	isInSegment, err := segmentStorage.SegmentContainsKey(m.segmentName, key)
+	isInSegment, err := storage.SegmentContainsKey(m.segmentName, key)
 	if err != nil {
 		m.logger.Error(fmt.Printf("InSegmentMatcher: Segment %s not found", m.segmentName))
 	}
@@ -28,12 +29,13 @@ func (m *InSegmentMatcher) Match(key string, attributes map[string]interface{}, 
 }
 
 // NewInSegmentMatcher instantiates a new InSegmentMatcher
-func NewInSegmentMatcher(negate bool, segmentName string, attributeName *string) *InSegmentMatcher {
+func NewInSegmentMatcher(negate bool, segmentName string, attributeName *string, segmentStorage storage.SegmentStorageConsumer) *InSegmentMatcher {
 	return &InSegmentMatcher{
 		Matcher: Matcher{
 			negate:        negate,
 			attributeName: attributeName,
 		},
-		segmentName: segmentName,
+		segmentName:    segmentName,
+		segmentStorage: segmentStorage,
 	}
 }

--- a/engine/grammar/insegment_test.go
+++ b/engine/grammar/insegment_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/splitio/go-split-commons/v6/storage/inmemory/mutexmap"
 
 	"github.com/splitio/go-toolkit/v5/datastructures/set"
-	"github.com/splitio/go-toolkit/v5/injection"
 	"github.com/splitio/go-toolkit/v5/logging"
 )
 
@@ -27,10 +26,7 @@ func TestInSegmentMatcher(t *testing.T) {
 	segmentStorage := mutexmap.NewMMSegmentStorage()
 	segmentStorage.Update("segmentito", segmentKeys, set.NewSet(), 123)
 
-	ctx := injection.NewContext()
-	ctx.AddDependency("segmentStorage", segmentStorage)
-
-	ruleBuilder := NewRuleBuilder(ctx, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, segmentStorage, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/ltoet_test.go
+++ b/engine/grammar/ltoet_test.go
@@ -23,7 +23,7 @@ func TestLessThanOrEqualToMatcherInt(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -63,7 +63,7 @@ func TestLessThanOrEqualToMatcherDatetime(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/matcher_test.go
+++ b/engine/grammar/matcher_test.go
@@ -21,7 +21,7 @@ func TestMatcherConstruction(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher1, err := ruleBuilder.BuildMatcher(&dto1)
 
@@ -74,7 +74,7 @@ func TestMatcherConstruction(t *testing.T) {
 	ctx := injection.NewContext()
 	ctx.AddDependency("key1", "sampleString")
 
-	ruleBuilder1 := NewRuleBuilder(ctx, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder1 := NewRuleBuilder(ctx, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher3, err := ruleBuilder1.BuildMatcher(&dto3)
 
@@ -84,10 +84,6 @@ func TestMatcherConstruction(t *testing.T) {
 
 	if !matcher3.Negate() {
 		t.Error("Matcher should be negated")
-	}
-
-	if matcher3.base().Context != ctx {
-		t.Error("Context not properly received", matcher3.base().Context)
 	}
 
 	dep := matcher3.base().Dependency("key1")

--- a/engine/grammar/matchers_test.go
+++ b/engine/grammar/matchers_test.go
@@ -51,14 +51,14 @@ func TestBuildMatcher_InRuleBasedSegment(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	ctx := injection.NewContext()
 
 	logger := logging.NewLogger(&logging.LoggerOptions{})
-	ctx := injection.NewContext()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			ruleBuilder := NewRuleBuilder(ctx, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+			ruleBuilder := NewRuleBuilder(ctx, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 			matcher, err := ruleBuilder.BuildMatcher(tt.dto)
 

--- a/engine/grammar/partofset_test.go
+++ b/engine/grammar/partofset_test.go
@@ -22,7 +22,7 @@ func TestPartOfSetMatcher(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/regex_test.go
+++ b/engine/grammar/regex_test.go
@@ -44,7 +44,7 @@ func TestRegexMatcher(t *testing.T) {
 			},
 		}
 
-		ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+		ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 		matcher, err := ruleBuilder.BuildMatcher(dto)
 		if err != nil {

--- a/engine/grammar/rulebuilder.go
+++ b/engine/grammar/rulebuilder.go
@@ -14,19 +14,21 @@ import (
 )
 
 type RuleBuilder struct {
-	ctx                     *injection.Context
+	Ctx                     *injection.Context
 	segmentStorage          storage.SegmentStorageConsumer
 	ruleBasedSegmentStorage storage.RuleBasedSegmentStorageConsumer
+	largeSegmentStorage     storage.LargeSegmentStorageConsumer
 	ffAcceptedMatchers      []string
 	rbAcceptedMatchers      []string
 	logger                  logging.LoggerInterface
 }
 
-func NewRuleBuilder(ctx *injection.Context, segmentStorage storage.SegmentStorageConsumer, ruleBasedSegmentStorage storage.RuleBasedSegmentStorageConsumer, ffAcceptedMatchers []string, rbAcceptedMatchers []string, logger logging.LoggerInterface) RuleBuilder {
+func NewRuleBuilder(ctx *injection.Context, segmentStorage storage.SegmentStorageConsumer, ruleBasedSegmentStorage storage.RuleBasedSegmentStorageConsumer, largeSegmentStorage storage.LargeSegmentStorageConsumer, ffAcceptedMatchers []string, rbAcceptedMatchers []string, logger logging.LoggerInterface) RuleBuilder {
 	return RuleBuilder{
-		ctx:                     ctx,
+		Ctx:                     ctx,
 		segmentStorage:          segmentStorage,
 		ruleBasedSegmentStorage: ruleBasedSegmentStorage,
+		largeSegmentStorage:     largeSegmentStorage,
 		ffAcceptedMatchers:      ffAcceptedMatchers,
 		rbAcceptedMatchers:      rbAcceptedMatchers,
 		logger:                  logger,
@@ -79,6 +81,7 @@ func (r RuleBuilder) BuildMatcher(dto *dtos.MatcherDTO) (MatcherInterface, error
 			dto.Negate,
 			dto.UserDefinedSegment.SegmentName,
 			attributeName,
+			r.segmentStorage,
 		)
 
 	case MatcherTypeWhitelist:
@@ -363,6 +366,7 @@ func (r RuleBuilder) BuildMatcher(dto *dtos.MatcherDTO) (MatcherInterface, error
 			dto.Negate,
 			dto.UserDefinedLargeSegment.LargeSegmentName,
 			attributeName,
+			r.largeSegmentStorage,
 		)
 	case MatcherTypeInRuleBasedSegment:
 		if dto.UserDefinedSegment == nil {
@@ -384,8 +388,8 @@ func (r RuleBuilder) BuildMatcher(dto *dtos.MatcherDTO) (MatcherInterface, error
 		}
 	}
 
-	if r.ctx != nil {
-		r.ctx.Inject(matcher.base())
+	if r.Ctx != nil {
+		r.Ctx.Inject(matcher.base())
 	}
 
 	matcher.base().logger = r.logger

--- a/engine/grammar/semver_test.go
+++ b/engine/grammar/semver_test.go
@@ -79,7 +79,7 @@ func TestEqualToSemverMatcher(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -105,7 +105,7 @@ func TestPatchDiffers(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -131,7 +131,7 @@ func TestPreReleaseShouldReturnTrueWhenVersionsAreEqual(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -157,7 +157,7 @@ func TestPreReleaseShouldReturnFalseWhenSemverIsNil(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -182,7 +182,7 @@ func TestPreReleaseShouldReturnFalseWhenVersionsDiffer(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -208,7 +208,7 @@ func TestMetadataShouldReturnTrueWhenVersionsAreEqual(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -234,7 +234,7 @@ func TestMetadataShouldReturnFalseWhenVersionsDiffer(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -255,7 +255,7 @@ func TestShouldReturnErrorWithNilSemver(t *testing.T) {
 		MatcherType: MatcherEqualToSemver,
 		String:      nil,
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	_, err := ruleBuilder.BuildMatcher(dto)
 	if err == nil {
@@ -280,7 +280,7 @@ func TestGreaterThanOrEqualToSemverMatcher(t *testing.T) {
 			},
 		}
 
-		ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+		ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 		matcher, err := ruleBuilder.BuildMatcher(dto)
 		if err != nil {
@@ -310,7 +310,7 @@ func TestGreaterThanOrEqualToSemverMatcherWithNilSemver(t *testing.T) {
 		MatcherType: MatcherTypeGreaterThanOrEqualToSemver,
 		String:      &semvers,
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -340,7 +340,7 @@ func TestLessThanOrEqualToSemverMatcher(t *testing.T) {
 				Attribute: &attrName,
 			},
 		}
-		ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+		ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 		matcher, err := ruleBuilder.BuildMatcher(dto)
 		if err != nil {
@@ -366,7 +366,7 @@ func TestLessThanOrEqualToSemverMatcherWithInvalidSemver(t *testing.T) {
 		MatcherType: MatcherTypeLessThanOrEqualToSemver,
 		String:      nil,
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	_, err := ruleBuilder.BuildMatcher(dto)
 	if err == nil {
@@ -385,7 +385,7 @@ func TestLessThanOrEqualToSemverMatcherWithNilSemver(t *testing.T) {
 		MatcherType: MatcherTypeLessThanOrEqualToSemver,
 		String:      &semvers,
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -418,7 +418,7 @@ func TestBetweenSemverMatcher(t *testing.T) {
 				Attribute: &attrName,
 			},
 		}
-		ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+		ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 		matcher, err := ruleBuilder.BuildMatcher(dto)
 		if err != nil {
@@ -447,7 +447,7 @@ func TestBetweenSemverWithNilSemvers(t *testing.T) {
 			End:   nil,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	_, err := ruleBuilder.BuildMatcher(dto)
 	if err == nil {
@@ -470,7 +470,7 @@ func TestBetweenSemverWithInvalidSemvers(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -498,7 +498,7 @@ func TestInListSemvers(t *testing.T) {
 		MatcherType: MatcherTypeInListSemver,
 		Whitelist:   &dtos.WhitelistMatcherDataDTO{Whitelist: semvers},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -531,7 +531,7 @@ func TestInListSemversNotMatch(t *testing.T) {
 		MatcherType: MatcherTypeInListSemver,
 		Whitelist:   &dtos.WhitelistMatcherDataDTO{Whitelist: semvers},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -565,7 +565,7 @@ func TestInListInvalidSemvers(t *testing.T) {
 			Attribute: &attrName,
 		},
 	}
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/split_test.go
+++ b/engine/grammar/split_test.go
@@ -24,7 +24,7 @@ func TestSplitCreation(t *testing.T) {
 		TrafficAllocationSeed: 333,
 		TrafficTypeName:       "tt1",
 	}
-	split := NewSplit(&dto, nil, logger, NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
+	split := NewSplit(&dto, nil, logger, NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
 
 	if split.Algo() != constants.SplitAlgoLegacy {
 		t.Error("Algo() should return legacy")
@@ -90,7 +90,7 @@ func TestSplitCreationWithConditionsMatcher(t *testing.T) {
 		TrafficAllocationSeed: 333,
 		TrafficTypeName:       "tt1",
 	}
-	split := NewSplit(&dto, nil, logger, NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
+	split := NewSplit(&dto, nil, logger, NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
 
 	if split.Algo() != constants.SplitAlgoLegacy {
 		t.Error("Algo() should return legacy")
@@ -160,7 +160,7 @@ func TestSplitCreationWithUnsupportedMatcher(t *testing.T) {
 		TrafficAllocationSeed: 333,
 		TrafficTypeName:       "tt1",
 	}
-	split := NewSplit(&dto, nil, logger, NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
+	split := NewSplit(&dto, nil, logger, NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger))
 
 	if split.Algo() != constants.SplitAlgoLegacy {
 		t.Error("Algo() should return legacy")

--- a/engine/grammar/startswith_test.go
+++ b/engine/grammar/startswith_test.go
@@ -22,7 +22,7 @@ func TestStartsWith(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/grammar/whitelist_test.go
+++ b/engine/grammar/whitelist_test.go
@@ -22,7 +22,7 @@ func TestWhitelistMatcherAttr(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {
@@ -53,7 +53,7 @@ func TestWhitelistMatcherKey(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := NewRuleBuilder(nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := NewRuleBuilder(nil, nil, nil, nil, SyncProxyFeatureFlagsRules, SyncProxyRuleBasedSegmentRules, logger)
 
 	matcher, err := ruleBuilder.BuildMatcher(dto)
 	if err != nil {

--- a/engine/validator/matchers_test.go
+++ b/engine/validator/matchers_test.go
@@ -34,7 +34,7 @@ func TestProcessRBMatchers(t *testing.T) {
 			},
 		},
 	}
-	validator := NewValidator(grammar.NewRuleBuilder(nil, nil, nil, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logging.NewLogger(nil)))
+	validator := NewValidator(grammar.NewRuleBuilder(nil, nil, nil, nil, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logging.NewLogger(nil)))
 	validator.ProcessRBMatchers(ruleBased, logging.NewLogger(nil))
 	if len(ruleBased.Conditions) != 1 {
 		t.Error("Conditions should have been overridden")
@@ -96,7 +96,7 @@ func TestProcessMatchers(t *testing.T) {
 			},
 		},
 	}
-	validator := NewValidator(grammar.NewRuleBuilder(nil, nil, nil, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logging.NewLogger(nil)))
+	validator := NewValidator(grammar.NewRuleBuilder(nil, nil, nil, nil, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logging.NewLogger(nil)))
 	validator.ProcessMatchers(split, logging.NewLogger(nil))
 	if len(split.Conditions) != 1 {
 		t.Error("Conditions should have been overridden")

--- a/synchronizer/local.go
+++ b/synchronizer/local.go
@@ -35,8 +35,8 @@ type LocalConfig struct {
 }
 
 // NewLocal creates new Local
-func NewLocal(cfg *LocalConfig, splitAPI *api.SplitAPI, splitStorage storage.SplitStorage, segmentStorage storage.SegmentStorage, ruleBasedStorage storage.RuleBasedSegmentsStorage, logger logging.LoggerInterface, runtimeTelemetry storage.TelemetryRuntimeProducer, hcMonitor application.MonitorProducerInterface) Synchronizer {
-	ruleBuilder := grammar.NewRuleBuilder(nil, segmentStorage, ruleBasedStorage, cfg.ffRulesAccepted, cfg.rbRulesAccepted, logger)
+func NewLocal(cfg *LocalConfig, splitAPI *api.SplitAPI, splitStorage storage.SplitStorage, segmentStorage storage.SegmentStorage, largeSegmentStorage storage.LargeSegmentsStorage, ruleBasedStorage storage.RuleBasedSegmentsStorage, logger logging.LoggerInterface, runtimeTelemetry storage.TelemetryRuntimeProducer, hcMonitor application.MonitorProducerInterface) Synchronizer {
+	ruleBuilder := grammar.NewRuleBuilder(nil, segmentStorage, ruleBasedStorage, largeSegmentStorage, cfg.ffRulesAccepted, cfg.rbRulesAccepted, logger)
 	splitUpdater := split.NewSplitUpdater(splitStorage, ruleBasedStorage, splitAPI.SplitFetcher, logger, runtimeTelemetry, hcMonitor, flagsets.NewFlagSetFilter(cfg.FlagSets), ruleBuilder)
 	splitUpdater.SetRuleBasedSegmentStorage(ruleBasedStorage)
 

--- a/synchronizer/local_test.go
+++ b/synchronizer/local_test.go
@@ -56,7 +56,8 @@ func TestLocalSyncAllError(t *testing.T) {
 	flagSetFilter := flagsets.NewFlagSetFilter(nil)
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	splitUpdater := split.NewSplitUpdater(
 		splitMockStorage,
 		ruleBasedSegmentMockStorage,
@@ -136,8 +137,8 @@ func TestLocalSyncAllOk(t *testing.T) {
 			atomic.AddInt64(&notifyEventCalled, 1)
 		},
 	}
-
-	syncForTest := NewLocal(&LocalConfig{}, &splitAPI, splitMockStorage, segmentMockStorage, ruleBasedSegmentMockStorage, logger, telemetryMockStorage, appMonitorMock)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	syncForTest := NewLocal(&LocalConfig{}, &splitAPI, splitMockStorage, segmentMockStorage, largeSegmentStorage, ruleBasedSegmentMockStorage, logger, telemetryMockStorage, appMonitorMock)
 	err := syncForTest.SyncAll()
 	if err != nil {
 		t.Error("It should not return error")
@@ -196,7 +197,8 @@ func TestLocalPeriodicFetching(t *testing.T) {
 		},
 	}
 
-	syncForTest := NewLocal(&LocalConfig{RefreshEnabled: true, SplitPeriod: 1}, &splitAPI, splitMockStorage, segmentMockStorage, ruleBasedSegmentMockStorage, logger, telemetryMockStorage, appMonitorMock)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	syncForTest := NewLocal(&LocalConfig{RefreshEnabled: true, SplitPeriod: 1}, &splitAPI, splitMockStorage, segmentMockStorage, largeSegmentStorage, ruleBasedSegmentMockStorage, logger, telemetryMockStorage, appMonitorMock)
 	syncForTest.StartPeriodicFetching()
 	time.Sleep(time.Millisecond * 1500)
 	if atomic.LoadInt64(&splitFetchCalled) != 1 {

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -48,7 +48,8 @@ func createSplitUpdater(splitMockStorage storageMock.MockSplitStorage, splitAPI 
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	splitUpdater := split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, telemetryMockStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 	return splitUpdater
 }
@@ -81,7 +82,9 @@ func TestSyncAllErrorSplits(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	splitUpdater := split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, telemetryMockStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	workers := Workers{
@@ -564,7 +567,9 @@ func TestSplitUpdateWorkerCNGreaterThanFFChange(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	workers := Workers{
 		SplitUpdater:   split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, telemetryMockStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder),
 		SegmentUpdater: segment.NewSegmentUpdater(splitMockStorage, segmentMockStorage, splitAPI.SegmentFetcher, logger, telemetryMockStorage, appMonitorMock),
@@ -620,8 +625,8 @@ func TestSplitUpdateWorkerStorageCNEqualsFFCN(t *testing.T) {
 
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
-
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	workers := Workers{
 		SplitUpdater:   split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, telemetryMockStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder),
 		SegmentUpdater: segment.NewSegmentUpdater(splitMockStorage, segmentMockStorage, splitAPI.SegmentFetcher, logger, telemetryMockStorage, appMonitorMock),
@@ -684,8 +689,9 @@ func TestSplitUpdateWorkerFFPcnEqualsFFNotNil(t *testing.T) {
 
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	workers := Workers{
 		SplitUpdater:   split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder),
 		SegmentUpdater: segment.NewSegmentUpdater(splitMockStorage, segmentMockStorage, splitAPI.SegmentFetcher, logger, telemetryStorage, appMonitorMock),
@@ -772,7 +778,9 @@ func TestSplitUpdateWorkerGetCNFromStorageError(t *testing.T) {
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	workers := Workers{
 		SplitUpdater:   split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, telemetryMockStorage, hcMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder),
 		SegmentUpdater: segment.NewSegmentUpdater(splitMockStorage, segmentMockStorage, splitAPI.SegmentFetcher, logger, telemetryMockStorage, hcMonitorMock),
@@ -845,7 +853,9 @@ func TestSplitUpdateWorkerFFIsNil(t *testing.T) {
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	workers := Workers{
 		SplitUpdater:   split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, telemetryMockStorage, hcMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder),
 		SegmentUpdater: segment.NewSegmentUpdater(splitMockStorage, segmentMockStorage, splitAPI.SegmentFetcher, logger, telemetryMockStorage, hcMonitorMock),
@@ -919,7 +929,8 @@ func TestSplitUpdateWorkerFFPcnDifferentStorageCN(t *testing.T) {
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	workers := Workers{
 		SplitUpdater:   split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, telemetryMockStorage, hcMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder),
 		SegmentUpdater: segment.NewSegmentUpdater(splitMockStorage, segmentMockStorage, splitAPI.SegmentFetcher, logger, telemetryMockStorage, hcMonitorMock),
@@ -972,7 +983,9 @@ func TestLocalKill(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	workers := Workers{
 		SplitUpdater: split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, storageMock.MockTelemetryStorage{}, hcMock.MockApplicationMonitor{}, flagsets.NewFlagSetFilter(nil), ruleBuilder),
 	}
@@ -1049,7 +1062,9 @@ func TestSplitUpdateWithReferencedSegments(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Maybe().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logger)
 	workers := Workers{
 		SplitUpdater:      split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitAPI.SplitFetcher, logger, telemetryMockStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder),
 		SegmentUpdater:    segment.NewSegmentUpdater(splitMockStorage, segmentMockStorage, splitAPI.SegmentFetcher, logger, telemetryMockStorage, appMonitorMock),

--- a/synchronizer/worker/split/split_test.go
+++ b/synchronizer/worker/split/split_test.go
@@ -77,7 +77,7 @@ func TestSplitSynchronizerError(t *testing.T) {
 			atomic.AddInt64(&notifyEventCalled, 1)
 		},
 	}
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 
 	splitUpdater := NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryMockStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
@@ -126,7 +126,7 @@ func TestSplitSynchronizerErrorScRequestURITooLong(t *testing.T) {
 		},
 	}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, nil, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryMockStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	_, err := splitUpdater.SynchronizeSplits(nil)
@@ -215,7 +215,9 @@ func TestSplitSynchronizer(t *testing.T) {
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Once().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryMockStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	_, err := splitUpdater.SynchronizeSplits(nil)
@@ -284,7 +286,9 @@ func TestSplitSyncProcess(t *testing.T) {
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Times(3).Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := NewSplitUpdater(splitStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	res, err := splitUpdater.SynchronizeSplits(nil)
@@ -382,7 +386,8 @@ func TestSplitTill(t *testing.T) {
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Times(12).Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Times(12).Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := NewSplitUpdater(splitStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	var till int64 = 1
@@ -454,8 +459,9 @@ func TestByPassingCDN(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Times(13).Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Times(13).Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := NewSplitUpdater(splitStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 	splitUpdater.onDemandFetchBackoffBase = 1
 	splitUpdater.onDemandFetchBackoffMaxWait = 10 * time.Nanosecond
@@ -526,8 +532,9 @@ func TestByPassingCDNLimit(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Times(22).Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Times(22).Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := NewSplitUpdater(splitStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 	splitUpdater.onDemandFetchBackoffBase = 1
 	splitUpdater.onDemandFetchBackoffMaxWait = 10 * time.Nanosecond
@@ -566,7 +573,9 @@ func TestProcessFFChange(t *testing.T) {
 	telemetryStorage, _ := inmemory.NewTelemetryStorage()
 	appMonitorMock := hcMock.MockApplicationMonitor{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	fetcher := NewSplitUpdater(ffStorageMock, ruleBasedSegmentMockStorage, splitMockFetcher, logger, telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	result, _ := fetcher.SynchronizeFeatureFlags(dtos.NewSplitChangeUpdate(
@@ -607,8 +616,9 @@ func TestAddOrUpdateFeatureFlagNil(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Once().Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	fetcher := NewSplitUpdater(ffStorageMock, ruleBasedSegmentMockStorage, splitMockFetcher, logger, telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	fetcher.SynchronizeFeatureFlags(dtos.NewSplitChangeUpdate(
@@ -652,7 +662,9 @@ func TestAddOrUpdateFeatureFlagPcnEquals(t *testing.T) {
 
 	telemetryStorage, _ := inmemory.NewTelemetryStorage()
 	appMonitorMock := hcMock.MockApplicationMonitor{}
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	fetcher := NewSplitUpdater(ffStorageMock, ruleBasedSegmentMockStorage, splitMockFetcher, logger, telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	featureFlag := dtos.SplitDTO{ChangeNumber: 4, Status: Active}
@@ -701,7 +713,8 @@ func TestAddOrUpdateFeatureFlagArchive(t *testing.T) {
 
 	telemetryStorage, _ := inmemory.NewTelemetryStorage()
 	appMonitorMock := hcMock.MockApplicationMonitor{}
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger)
 	fetcher := NewSplitUpdater(ffStorageMock, ruleBasedSegmentMockStorage, splitMockFetcher, logger, telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	featureFlag := dtos.SplitDTO{ChangeNumber: 4, Status: Archived}
@@ -749,8 +762,9 @@ func TestAddOrUpdateFFCNFromStorageError(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Once().Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger)
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logger)
 	fetcher := NewSplitUpdater(ffStorageMock, ruleBasedSegmentMockStorage, splitMockFetcher, logger, telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	fetcher.SynchronizeFeatureFlags(dtos.NewSplitChangeUpdate(
@@ -772,8 +786,9 @@ func TestGetActiveFF(t *testing.T) {
 
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	s := NewSplitUpdater(mocks.MockSplitStorage{}, ruleBasedSegmentMockStorage, fetcherMock.MockSplitFetcher{}, nil, mocks.MockTelemetryStorage{}, hcMock.MockApplicationMonitor{}, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 	actives, inactives := s.processFeatureFlagChanges(featureFlagChanges)
 
@@ -794,8 +809,9 @@ func TestGetInactiveFF(t *testing.T) {
 
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	s := NewSplitUpdater(mocks.MockSplitStorage{}, ruleBasedSegmentMockStorage, fetcherMock.MockSplitFetcher{}, nil, mocks.MockTelemetryStorage{}, hcMock.MockApplicationMonitor{}, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 	actives, inactives := s.processFeatureFlagChanges(featureFlagChanges)
 
@@ -817,8 +833,9 @@ func TestGetActiveAndInactiveFF(t *testing.T) {
 
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	s := NewSplitUpdater(mocks.MockSplitStorage{}, ruleBasedSegmentMockStorage, fetcherMock.MockSplitFetcher{}, nil, mocks.MockTelemetryStorage{}, hcMock.MockApplicationMonitor{}, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 	actives, inactives := s.processFeatureFlagChanges(featureFlagChanges)
 
@@ -868,8 +885,9 @@ func TestSplitSyncWithSets(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Once().Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := NewSplitUpdater(splitStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryStorage, appMonitorMock, flagsets.NewFlagSetFilter([]string{"set1", "set2", "set3"}), ruleBuilder)
 
 	res, err := splitUpdater.SynchronizeSplits(nil)
@@ -931,8 +949,9 @@ func TestSplitSyncWithSetsInConfig(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Once().Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := NewSplitUpdater(splitStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryStorage, appMonitorMock, flagSetFilter, ruleBuilder)
 
 	res, err := splitUpdater.SynchronizeSplits(nil)
@@ -1006,7 +1025,8 @@ func TestSynchronizeSplitsWithLowerTill(t *testing.T) {
 	appMonitorMock := hcMock.MockApplicationMonitor{
 		NotifyEventCall: func(counterType int) {},
 	}
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	// Create split updater
 	splitUpdater := NewSplitUpdater(
 		splitMockStorage,
@@ -1118,7 +1138,9 @@ func TestSynchronizeFeatureFlagsRuleBasedUpdate(t *testing.T) {
 	appMonitorMock := hcMock.MockApplicationMonitor{
 		NotifyEventCall: func(counterType int) {},
 	}
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 
 	// Create split updater
 	splitUpdater := NewSplitUpdater(
@@ -1242,8 +1264,9 @@ func TestSynchronizeFeatureFlagsRuleBasedUpdate(t *testing.T) {
 func TestProcessMatchers(t *testing.T) {
 	ruleBasedSegmentMockStorage := &mocks.MockRuleBasedSegmentStorage{}
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
+	largeSegmentStorage := &mocks.MockLargeSegmentStorage{}
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, largeSegmentStorage, syncProxyFeatureFlagsRules, syncProxyRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := NewSplitUpdater(mocks.MockSplitStorage{}, ruleBasedSegmentMockStorage, fetcherMock.MockSplitFetcher{}, logging.NewLogger(nil), mocks.MockTelemetryStorage{}, hcMock.MockApplicationMonitor{}, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 	splitChange := &dtos.SplitChangesDTO{
 		FeatureFlags: dtos.FeatureFlagsDTO{Till: 1, Since: 1, Splits: []dtos.SplitDTO{

--- a/tasks/splitsync_test.go
+++ b/tasks/splitsync_test.go
@@ -105,7 +105,7 @@ func TestSplitSyncTask(t *testing.T) {
 	ruleBasedSegmentMockStorage.On("ChangeNumber").Twice().Return(-1)
 	ruleBasedSegmentMockStorage.On("Update", mock.Anything, mock.Anything, mock.Anything).Once().Return(-1)
 
-	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
+	ruleBuilder := grammar.NewRuleBuilder(nil, nil, ruleBasedSegmentMockStorage, nil, goClientFeatureFlagsRules, goClientRuleBasedSegmentRules, logging.NewLogger(&logging.LoggerOptions{}))
 	splitUpdater := split.NewSplitUpdater(splitMockStorage, ruleBasedSegmentMockStorage, splitMockFetcher, logging.NewLogger(&logging.LoggerOptions{}), telemetryMockStorage, appMonitorMock, flagsets.NewFlagSetFilter(nil), ruleBuilder)
 
 	splitTask := NewFetchSplitsTask(


### PR DESCRIPTION
# GO SPLIT COMMONS

## What did you accomplish?
- Added storage in matchers inSegment, inLargeSegment, and inRuleBasedSegment to not use the context.
- 
## How do we test the changes introduced in this PR?

## Extra Notes
