### PR TITLE
[FME-14174] Added atomic int to validate id the sse client it's running or not

### DIFF
--- a/service/api/sse/client.go
+++ b/service/api/sse/client.go
@@ -3,6 +3,7 @@ package sse
 import (
 	"errors"
 	"strings"
+	"sync/atomic"
 
 	"github.com/splitio/go-split-commons/v9/conf"
 	"github.com/splitio/go-split-commons/v9/dtos"
@@ -16,6 +17,12 @@ import (
 const (
 	version   = "1.1"
 	keepAlive = 70
+)
+
+const (
+	StateIdle      int32 = 0  // Client is idle/not started
+	StateRunning   int32 = 1  // Client is running
+	StateDestroyed int32 = -1 // Client is destroyed/stopped
 )
 
 // StreamingClient interface
@@ -32,6 +39,7 @@ type StreamingClientImpl struct {
 	lifecycle lifecycle.Manager
 	metadata  dtos.Metadata
 	clientKey *string
+	state     atomic.Int32 // Atomic state: 0=Idle, 1=Running, -1=Destroyed
 }
 
 // Status constants
@@ -54,15 +62,20 @@ func NewStreamingClient(cfg *conf.AdvancedConfig, logger logging.LoggerInterface
 		metadata:  metadata,
 		clientKey: clientKey,
 	}
+	client.state.Store(StateIdle)
 	client.lifecycle.Setup()
 	return client
 }
 
 // ConnectStreaming connects to streaming
 func (s *StreamingClientImpl) ConnectStreaming(token string, streamingStatus chan int, channelList []string, handleIncomingMessage func(IncomingMessage)) {
-
+	if !s.state.CompareAndSwap(StateIdle, StateRunning) {
+		s.logger.Info("Client is not in idle state (already running or destroyed). Ignoring")
+		return
+	}
 	if !s.lifecycle.BeginInitialization() {
 		s.logger.Info("Connection is already in process/running. Ignoring")
+		s.state.Store(StateIdle) // Reset state since lifecycle check failed
 		return
 	}
 
@@ -72,8 +85,25 @@ func (s *StreamingClientImpl) ConnectStreaming(token string, streamingStatus cha
 	params["v"] = version
 
 	go func() {
-		defer s.lifecycle.ShutdownComplete()
+		defer func() {
+			s.lifecycle.ShutdownComplete()
+			// Reset to idle if not destroyed
+			if s.state.Load() != StateDestroyed {
+				s.state.Store(StateIdle)
+			}
+		}()
+
+		// Early exit if client was destroyed while goroutine was starting
+		if s.state.Load() <= StateIdle {
+			s.logger.Info("Client state is not valid (destroyed or idle). Exiting goroutine")
+			return
+		}
 		if !s.lifecycle.InitializationComplete() {
+			return
+		}
+		// Final check before starting connection - prevent race if Destroy was called
+		if s.state.Load() != StateRunning {
+			s.logger.Info("Client destroyed before connection started. Exiting goroutine")
 			return
 		}
 		firstEventReceived := gtSync.NewAtomicBool(false)
@@ -113,6 +143,8 @@ func (s *StreamingClientImpl) ConnectStreaming(token string, streamingStatus cha
 
 // StopStreaming stops streaming
 func (s *StreamingClientImpl) StopStreaming() {
+	// Set atomic state to destroyed immediately to prevent new goroutines
+	s.state.Store(StateDestroyed)
 	if !s.lifecycle.BeginShutdown() {
 		s.logger.Info("SSE client wrapper not running. Ignoring")
 		return
@@ -124,5 +156,5 @@ func (s *StreamingClientImpl) StopStreaming() {
 
 // IsRunning returns true if the client is running
 func (s *StreamingClientImpl) IsRunning() bool {
-	return s.lifecycle.IsRunning()
+	return s.lifecycle.IsRunning() && s.state.Load() == StateRunning
 }


### PR DESCRIPTION
AI-Session-Id: c7482875-263c-4eb4-ad97-77793a6e20f1
AI-Tool: claude-code
AI-Model: unknown

# GO SPLIT COMMONS

## What did you accomplish?
<!-- A brief explanation synthesizing the feature, bug or fix. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How do we test the changes introduced in this PR?

## Extra Notes
